### PR TITLE
Update network APIs to support HTTP2 connection

### DIFF
--- a/lib/include/fdonet.h
+++ b/lib/include/fdonet.h
@@ -24,13 +24,13 @@ bool resolve_dn(const char *dn, fdo_ip_address_t **ip, uint16_t port, bool tls,
 		bool proxy);
 
 bool connect_to_manufacturer(fdo_ip_address_t *ip, const char *dn,
-			     uint16_t port, fdo_con_handle *sock_hdl, bool tls);
+			     uint16_t port, bool tls);
 
 bool connect_to_rendezvous(fdo_ip_address_t *ip, const char *dn, uint16_t port,
-			   fdo_con_handle *sock_hdl, bool tls);
+			   bool tls);
 
 bool connect_to_owner(fdo_ip_address_t *ip, const char *dn, uint16_t port,
-		      fdo_con_handle *sock_hdl, bool tls);
+		      bool tls);
 
 /* Try reconnecting to server if connection lost */
 int fdo_connection_restablish(fdo_prot_ctx_t *prot_ctx);

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -152,7 +152,7 @@ typedef struct fdo_prot_s {
 	fdo_dev_cred_t *dev_cred;
 	fdo_public_key_t *owner_public_key; // Owner's public key
 	fdo_service_info_t *service_info;   // store System ServiceInfo
-					  // (devmod+unsupported module list)
+					    // (devmod+unsupported module list)
 	fdo_byte_array_t *ext_service_info; // store External module
 					    // ServiceInfoVal (fdo_sys, for ex.)
 	fdo_public_key_t *tls_key; // unused for now

--- a/lib/include/fdoprotctx.h
+++ b/lib/include/fdoprotctx.h
@@ -21,7 +21,6 @@ typedef struct {
 
 // FDO protocol context
 typedef struct fdo_prot_ctx_s {
-	fdo_con_handle sock_hdl;
 	bool tls;
 	int msg_type;
 	fdo_prot_t *protdata;

--- a/network/include/network_al.h
+++ b/network/include/network_al.h
@@ -21,7 +21,6 @@
 #define MAX_TIME_OUT 60000L
 
 #ifndef TARGET_OS_MBEDOS
-typedef void *fdo_con_handle;
 #define FDO_CON_INVALID_HANDLE NULL
 #endif
 
@@ -59,17 +58,16 @@ int32_t fdo_con_dns_lookup(const char *url, fdo_ip_address_t **ip_list,
  * @param[in] tls: flag describing whether HTTP (false) or HTTPS (true) is
  * @retval -1 on failure, connection handle on success.
  */
-fdo_con_handle fdo_con_connect(fdo_ip_address_t *addr, const char *dn,
-			       uint16_t port, bool tls);
+int32_t fdo_con_connect(fdo_ip_address_t *addr, const char *dn, uint16_t port,
+			bool tls);
 
 /*
  * Disconnect the connection.
  *
- * @param[in] handle: connection handler (for ex: socket-id)
  * @param[in] tls: flag describing whether HTTP (false) or HTTPS (true) is
  * @retval -1 on failure, 0 on success.
  */
-int32_t fdo_con_disconnect(fdo_con_handle handle);
+int32_t fdo_con_disconnect(void);
 
 /*
  * Check the REST header for given REST response buffer and offset.
@@ -97,48 +95,42 @@ bool get_msg_length(char *curl_buf, size_t *cur_offset, uint32_t *msglen);
 /*
  * Receive(read) length of incoming fdo packet.
  *
- * @param[in] handle: connection handler (for ex: socket-id)
  * @param[out] protocol_version: FDO protocol version
  * @param[out] message_type: message type of incoming FDO message.
  * @param[out] msglen: length of incoming message.
- * @param[in] tls: flag describing whether HTTP (false) or HTTPS (true) is
- * @param[out] curl_buf: data buffer to read into msg received by curl.
- * @param[out] curl_buf_offset: pointer to track curl_buf.
+ * @param[in] hdr_buf: data buffer to parse msg received by curl.
  * @retval -1 on failure, 0 on success.
  */
-int32_t fdo_con_recv_msg_header(fdo_con_handle handle,
-				uint32_t *protocol_version,
-				uint32_t *message_type, uint32_t *msglen,
-				char *curl_buf, size_t *curl_buf_offset);
+int32_t fdo_con_parse_msg_header(uint32_t *protocol_version,
+				 uint32_t *message_type, uint32_t *msglen,
+				 char *hdr_buf);
 
 /*
  * Receive(read) incoming fdo packet.
  *
- * @param[in] handle: connection handler (for ex: socket-id)
  * @param[out] buf: data buffer to read into.
  * @param[in] length: Number of received bytes to be read.
- * @param[in] tls: flag describing whether HTTP (false) or HTTPS (true) is
- * @param[in] curl_buf: data buffer to read into msg received by curl.
- * @param[in] curl_buf_offset: pointer to track curl_buf.
+ * @param[in] body_buf: data buffer to parse msg received by curl.
  * @retval -1 on failure, 0 on success.
  */
-int32_t fdo_con_recv_msg_body(uint8_t *buf, size_t length, char *curl_buf,
-			      size_t curl_buf_offset);
+int32_t fdo_con_parse_msg_body(uint8_t *buf, size_t length, char *body_buf);
 
 /*
  * Send(write) data.
  *
- * @param[in] handle: connection handler (for ex: socket-id)
  * @param[in] protocol_version: FDO protocol version
  * @param[in] message_type: message type of outgoing FDO message.
  * @param[in] buf: data buffer to write from.
  * @param[in] length: Number of sent bytes.
  * @param[in] tls: flag describing whether HTTP (false) or HTTPS (true) is
+ * @param[in] header_buf: header data buffer to read into  msg received by curl.
+ * @param[in] body_buf: body data buffer to read into  msg received by curl.
  * @retval -1 on failure, 0 on success.
  */
-int32_t fdo_con_send_message(fdo_con_handle handle, uint32_t protocol_version,
-			     uint32_t message_type, const uint8_t *buf,
-			     size_t length, bool tls);
+int32_t fdo_con_send_recv_message(uint32_t protocol_version,
+				  uint32_t message_type, const uint8_t *buf,
+				  size_t length, bool tls, char *header_buf,
+				  char *body_buf);
 
 /*
  * Network Connection tear down.
@@ -170,15 +162,15 @@ const char *get_device_serial_number(void);
 int fdo_random(void);
 
 /**
- * fdo_curl_setup connects to the given ip_addr via curl API
+ * fdo_curl_connect connects to the given ip_addr via curl API
  *
  * @param ip_addr[in] - pointer to IP address info
  * @param dn: Domain name of the server
  * @param port[in] - port number to connect
- * @return connection handle on success. -ve value on failure
+ * @return 0 on success. -1 on failure
  */
-int fdo_curl_setup(fdo_ip_address_t *ip_addr, const char *dn, uint16_t port,
-		   bool tls);
+int32_t fdo_curl_connect(fdo_ip_address_t *ip_addr, const char *dn,
+			 uint16_t port, bool tls);
 
 /**
  * fdo_curl_proxy set up the proxy connection via curl API

--- a/network/include/rest_interface.h
+++ b/network/include/rest_interface.h
@@ -45,6 +45,11 @@ typedef struct Rest_ctx_s {
 	bool is_dns;
 } rest_ctx_t;
 
+struct MemoryStruct {
+	char *memory;
+	size_t size;
+};
+
 extern CURL *curl;
 
 bool cache_host_dns(const char *dns);
@@ -53,7 +58,8 @@ bool cache_host_port(uint16_t port);
 bool cache_tls_connection(void);
 bool init_rest_context(void);
 rest_ctx_t *get_rest_context(void);
-bool construct_rest_header(rest_ctx_t *rest, char *header, size_t header_len);
+bool construct_rest_header(rest_ctx_t *rest, struct curl_slist **msg_header,
+			   size_t header_len);
 char get_rest_hdr_body_separator(void);
 bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len);
 void exit_rest_context(void);

--- a/tests/unit/test_fdonet.c
+++ b/tests/unit/test_fdonet.c
@@ -24,8 +24,8 @@ bool __wrap_cache_host_ip(fdo_ip_address_t *ip);
 bool __wrap_cache_host_port(uint16_t port);
 int32_t __wrap_fdo_con_dns_lookup(char *dns, fdo_ip_address_t **ip_list,
 				  uint32_t *ip_list_size);
-fdo_con_handle __wrap_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
-				      void **ssl);
+int32_t __wrap_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
+			       void **ssl);
 fdo_byte_array_t *__wrap_fdo_byte_array_alloc(int byte_sz);
 bool __wrap_fdor_init(fdor_t *fdor, FDOReceive_fcn_ptr_t rcv, void *rcv_data);
 void test_setup_http_proxy(void);
@@ -98,13 +98,13 @@ int32_t __wrap_fdo_con_dns_lookup(char *dns, fdo_ip_address_t **ip_list,
 }
 
 static bool connect_fail = false;
-fdo_con_handle __real_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
-				      void **ssl);
-fdo_con_handle __wrap_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
-				      void **ssl)
+int32_t __real_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
+			       void **ssl);
+int32_t __wrap_fdo_con_connect(fdo_ip_address_t *ip_addr, uint16_t port,
+			       void **ssl)
 {
 	if (connect_fail)
-		return FDO_CON_INVALID_HANDLE;
+		return -1;
 	else
 		return __real_fdo_con_connect(ip_addr, port, ssl);
 }
@@ -205,25 +205,23 @@ void test_Connect_toManufacturer(void)
 
 	uint16_t port = 8039;
 	bool ret = false;
-	fdo_con_handle sock = FDO_CON_INVALID_HANDLE;
-
 	ip.length = 4;
 
-	ret = connect_to_manufacturer(NULL, NULL, 0, NULL, NULL);
+	ret = connect_to_manufacturer(NULL, NULL, 0, NULL);
 	TEST_ASSERT_FALSE(ret);
 
 	cache_ip_fail = true;
-	ret = connect_to_manufacturer(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_manufacturer(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_ip_fail = false;
 
 	cache_port_fail = true;
-	ret = connect_to_manufacturer(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_manufacturer(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_port_fail = false;
 
 	connect_fail = true;
-	ret = connect_to_manufacturer(NULL, NULL, port, &sock, NULL);
+	ret = connect_to_manufacturer(NULL, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	connect_fail = false;
 }
@@ -240,25 +238,23 @@ void test_Connect_toRendezvous(void)
 
 	uint16_t port = 8041;
 	bool ret = false;
-	fdo_con_handle sock = FDO_CON_INVALID_HANDLE;
-
 	ip.length = 4;
 
-	ret = connect_to_rendezvous(NULL, NULL, 0, NULL, NULL);
+	ret = connect_to_rendezvous(NULL, NULL, 0, NULL);
 	TEST_ASSERT_FALSE(ret);
 
 	cache_ip_fail = true;
-	ret = connect_to_rendezvous(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_rendezvous(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_ip_fail = false;
 
 	cache_port_fail = true;
-	ret = connect_to_rendezvous(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_rendezvous(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_port_fail = false;
 
 	connect_fail = true;
-	ret = connect_to_rendezvous(NULL, NULL, port, &sock, NULL);
+	ret = connect_to_rendezvous(NULL, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	connect_fail = false;
 }
@@ -275,25 +271,23 @@ void test_Connect_toOwner(void)
 
 	uint16_t port = 8042;
 	bool ret = false;
-	fdo_con_handle sock = FDO_CON_INVALID_HANDLE;
-
 	ip.length = 4;
 
-	ret = connect_to_owner(NULL, NULL, 0, NULL, NULL);
+	ret = connect_to_owner(NULL, NULL, 0, NULL);
 	TEST_ASSERT_FALSE(ret);
 
 	cache_ip_fail = true;
-	ret = connect_to_owner(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_owner(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_ip_fail = false;
 
 	cache_port_fail = true;
-	ret = connect_to_owner(&ip, NULL, port, &sock, NULL);
+	ret = connect_to_owner(&ip, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	cache_port_fail = false;
 
 	connect_fail = true;
-	ret = connect_to_owner(NULL, NULL, port, &sock, NULL);
+	ret = connect_to_owner(NULL, NULL, port, NULL);
 	TEST_ASSERT_FALSE(ret);
 	connect_fail = false;
 }

--- a/tests/unit/test_protctx.c
+++ b/tests/unit/test_protctx.c
@@ -224,7 +224,6 @@ TEST_CASE("fdo_prot_ctx_run", "[protctx][fdo]")
 	prot_ctx->protdata = fdo_alloc(sizeof(fdo_prot_t));
 	TEST_ASSERT_NOT_NULL(prot_ctx->protdata);
 
-	prot_ctx->sock_hdl = FDO_CON_INVALID_HANDLE;
 	return_socket = -1;
 	prot_ctx->protrun = &fdo_prot_dummy;
 	prot_ctx->host_port = host_port;


### PR DESCRIPTION
Older network APIs were using sockets for communication and supported only HTTP1.1 connection. 
Remove socket dependency and move to Curl APIs for network communication.