### PR TITLE
Update steps to build curl with nghttp2 and fix memory leak

### DIFF
--- a/docs/cse.md
+++ b/docs/cse.md
@@ -18,8 +18,8 @@ The linux kernel should have the support to enable the Intel<sup>&reg;</sup> CSE
 ## 1. Packages Requirements when Building Binaries:
 * For Ubuntu* OS version 20.04 or 22.04 / Debian 11.4:
 ```shell
-sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby build-essential \
-  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake libssl-dev mercurial
+sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby \
+  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake libssl-dev mercurial nghttp2 libnghttp2-dev
 ```
 
 * For RHEL* OS version 8.4 or 8.6:
@@ -29,7 +29,7 @@ sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.
 ```
 ```
 sudo yum -y install gcc gcc-c++ python3-setuptools git-clang-format dos2unix ruby perl glibc-static \
-  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake openssl-devel make mercurial perl
+  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake openssl-devel make mercurial perl nghttp2 libnghttp2-devel
 ```
 ## 2. Packages Requirements when Executing Binaries:
 
@@ -121,9 +121,9 @@ After installing openssl, proceed with the installation of curl.
 	```
 	tar -zxf curl-8.1.2.tar.gz && cd curl-8.1.2
 	```
-3. Issue the command to configure the curl with openssl:
+3. Issue the command to configure the curl with openssl and nghttp2:
 	```
-	./configure --with-openssl="OpenSSL Path" --enable-versioned-symbols
+	./configure --with-openssl="OpenSSL Path" --with-nghttp2 --enable-versioned-symbols
 	```
 4. Issue the command to build curl:
 	```

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,9 +1,4 @@
 
-
-
-
-
-
 # Linux* OS
 The development and execution OS used was `Ubuntu* OS version 20.04 or 22.04 / RHEL* OS version 8.4 or 8.6 / Debian 11.4` on x86. Follow these steps to compile and execute FIDO Device Onboard (FDO).
 
@@ -12,8 +7,8 @@ The FDO Client SDK execution depends on OpenSSL* toolkit 3.0.8 version. Users mu
 ## 1. Packages Requirements when Building Binaries:
 * For Ubuntu* OS version 20.04 or 22.04 / Debian 11.4:
 ```shell
-sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby build-essential \
-  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake mercurial
+sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby \
+  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake mercurial nghttp2 libnghttp2-dev
 ```
 
 * For RHEL* OS version 8.4 or 8.6:
@@ -23,7 +18,7 @@ sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.
 ```
 ```
 sudo yum -y install gcc gcc-c++ python3-setuptools git-clang-format dos2unix ruby perl glibc-static \
-  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake make mercurial perl
+  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake make mercurial perl nghttp2 libnghttp2-devel
 ```
 ## 2. Packages Requirements when Executing Binaries:
 
@@ -121,9 +116,9 @@ After installing openssl, proceed with the installation of curl.
 	```
 	tar -zxf curl-8.1.2.tar.gz && cd curl-8.1.2
 	```
-3. Issue the command to configure the curl with openssl:
+3. Issue the command to configure the curl with openssl and nghttp2:
 	```
-	./configure --with-openssl="OpenSSL Path" --enable-versioned-symbols
+	./configure --with-openssl="OpenSSL Path" --with-nghttp2 --enable-versioned-symbols
 	```
 4. Issue the command to build curl:
 	```

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -16,8 +16,8 @@ The FDO Client SDK execution depends on OpenSSL* toolkit 3.0.8 version. Users mu
 
 * For Ubuntu* OS version 20.04 or 22.04 / Debian 11.4:
 ```shell
-sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby build-essential \
-  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake mercurial
+sudo apt-get install build-essential python-setuptools clang-format dos2unix ruby \
+  libglib2.0-dev libpcap-dev autoconf libtool libproxy-dev doxygen cmake mercurial nghttp2 libnghttp2-dev
 ```
 
 * For RHEL* OS version 8.4 or 8.6:
@@ -27,7 +27,7 @@ sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.
 ```
 ```
 sudo yum -y install gcc gcc-c++ python3-setuptools git-clang-format dos2unix ruby perl glibc-static \
-  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake make mercurial
+  glib2-devel libpcap-devel autoconf libtool libproxy-devel mozjs52-devel doxygen cmake make mercurial nghttp2 libnghttp2-devel
 ```
 
 OpenSSL* toolkit version 3.0.8.
@@ -119,9 +119,9 @@ After installing openssl, proceed with the installation of curl.
 	```
 	tar -zxf curl-8.1.2.tar.gz && cd curl-8.1.2
 	```
-3. Issue the command to configure the curl with openssl:
+3. Issue the command to configure the curl with openssl and nghttp2:
 	```
-	./configure --with-openssl="OpenSSL Path" --enable-versioned-symbols
+	./configure --with-openssl="OpenSSL Path" --with-nghttp2 --enable-versioned-symbols
 	```
 4. Issue the command to build curl:
 	```

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -843,6 +843,7 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	int ret = -1;
 	rest_ctx_t *rest = NULL;
 	struct curl_slist *msg_header = NULL;
+	struct curl_slist *temp_msg_header = NULL;
 	CURLcode curlCode;
 	struct MemoryStruct temp_header_buf;
 	struct MemoryStruct temp_body_buf;
@@ -868,7 +869,8 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 		rest->tls = true;
 	}
 
-	if (!construct_rest_header(rest, &msg_header, REST_MAX_MSGHDR_SIZE)) {
+	if (!construct_rest_header(rest, &msg_header, REST_MAX_MSGHDR_SIZE) ||
+	    msg_header == NULL) {
 		LOG(LOG_ERROR, "Error during constrcution of REST hdr!\n");
 		goto err;
 	}
@@ -927,9 +929,10 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	LOG(LOG_DEBUG, "\nSending REST header.\n\n");
 	LOG(LOG_DEBUG, "REST:header\n");
 
-	while (msg_header != NULL) {
-		LOG(LOG_DEBUG, "%s\n", msg_header->data);
-		msg_header = msg_header->next;
+	temp_msg_header = msg_header;
+	while (temp_msg_header != NULL) {
+		LOG(LOG_DEBUG, "%s\n", temp_msg_header->data);
+		temp_msg_header = temp_msg_header->next;
 	}
 	LOG(LOG_DEBUG, "\n");
 

--- a/utils/install_openssl_curl.sh
+++ b/utils/install_openssl_curl.sh
@@ -31,7 +31,7 @@ install()
     tar -xvzf curl-$CURL_VER.tar.gz
     cd curl-$CURL_VER
 
-    ./configure --prefix=$CURL_ROOT --with-openssl=$OPENSSL_ROOT --enable-versioned-symbols
+    ./configure --prefix=$CURL_ROOT --with-openssl=$OPENSSL_ROOT --with-nghttp2 --enable-versioned-symbols
     make -j$(nproc)
     make install
     


### PR DESCRIPTION
Update steps to build curl with nghttp2 in Readme and installation script

- Add --with-nghttp2 flag to build curl to support HTTP2
- Fix memory leak caused by curl_slist_append()