### PR TITLE
SVI [exec, exec_cb and fetch] fix

### DIFF
--- a/device_modules/fdo_sys/fdo_sys.c
+++ b/device_modules/fdo_sys/fdo_sys.c
@@ -404,6 +404,7 @@ int FDO_SI_IS_MORE_DSI_FUNCTION(int result, bool *is_more)
 	// for simplicity, setting this to 'false' always,
 	// since managing 'ismore' by looking-ahead can be error-prone
 	*is_more = ismore;
+	result = FDO_SI_SUCCESS;
 	return result;
 }
 


### PR DESCRIPTION
Onboarding of device was failing with SVI [exec, exec_cb and fetch] because of returning invalid value.
Fixed SVI by returning correct value.