### PR TITLE
Add support for tar.gz files to the SVI instruction

### DIFF
--- a/device_modules/fdo_sys/fdo_sys.c
+++ b/device_modules/fdo_sys/fdo_sys.c
@@ -838,8 +838,8 @@ int FDO_SI_SET_OSI_EXEC(int result, uint8_t *bin_data, char **exec_instr,
 			return result;
 		}
 
-		// 2nd argument is the filename
-		if (exec_array_index == 1) {
+		// last argument is the filename
+		if (exec_array_index == ((int)exec_array_length - 1)) {
 			if (memset_s(filename, sizeof(filename), 0) != 0) {
 				LOG(LOG_DEBUG, "Module fdo_sys - Failed "
 					       "to clear filename for"

--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -21,7 +21,7 @@ static bool is_valid_filename(const char *fname)
 	bool ret = false;
 	int strcmp_result = -1;
 	uint8_t i = 0;
-	static const char *const whitelisted[] = {"sh", "py"};
+	static const char *const whitelisted[] = {"sh", "py", "tar", "gz"};
 	char *substring = NULL, *t1 = NULL;
 	char filenme_woextension[FILE_NAME_LEN] = {0};
 	size_t fname_len = 0;
@@ -73,6 +73,7 @@ static bool is_valid_filename(const char *fname)
 	}
 	ret = false;
 	t1 = filenme_woextension;
+	strcmp_result = -1;
 
 	// check for only alphanumeric no special char except underscore '_' and
 	// hyphen '-'
@@ -82,7 +83,12 @@ static bool is_valid_filename(const char *fname)
 		    (*t1 == '-')) {
 			t1++;
 		} else {
-			goto end;
+			strcmp_s(substring, ext_len, "gz", &strcmp_result);
+			if (*t1 == '.' && !strcmp_result) {
+				t1++;
+			} else {
+				goto end;
+			}
 		}
 	}
 


### PR DESCRIPTION
SVI instruction was failing when provided with tar files.
Added support for tar files to the exec, exec_cb, and fetch commands.