### PR TITLE
Add run time argument to take input for manufacturer address

### DIFF
--- a/docs/cse.md
+++ b/docs/cse.md
@@ -254,6 +254,10 @@ After a successful compilation, the Intel<sup>&reg;</sup> CSE enabled FDO Client
   ```shell
   sudo ./build/linux-client
   ```
+> ***NOTE***: Usage: `linux-client -ip <http|https>://<mfg addr>:<port>`
+        if -ip not specified, manufacturer_addr.bin will be used
+        `-ss`: specify if backend servers are using self-signed certificates
+        `-r`: enable resale
 > ***NOTE***: To do the DI again we need to clear the Device status from CSE storage.
 > To clear the storage, compile the code with "-DCSE_CLEAR=true" flag and then execute the following command
 ```shell

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,5 +1,6 @@
 
 
+
 # Linux* OS
 The development and execution OS used was `Ubuntu* OS version 20.04 or 22.04 / RHEL* OS version 8.4 or 8.6 / Debian 11.4` on x86. Follow these steps to compile and execute FIDO Device Onboard (FDO).
 
@@ -229,3 +230,8 @@ After a successful compilation, the FDO Client SDK Linux device executable can b
   ```shell
   ./build/linux-client
   ```
+
+> ***NOTE***: Usage: `linux-client -ip <http|https>://<mfg addr>:<port>`
+        if -ip not specified, manufacturer_addr.bin will be used
+        `-ss`: specify if backend servers are using self-signed certificates
+        `-r`: enable resale

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -377,6 +377,10 @@ After a successful compilation, the FDO Client SDK Linux device executable can b
   ./build/linux-client
   ```
 > ***NOTE***:  linux-client may require elevated privileges. Please use 'sudo' to execute.
+> ***NOTE***: Usage: `linux-client -ip <http|https>://<mfg addr>:<port>`
+        if -ip not specified, manufacturer_addr.bin will be used
+        `-ss`: specify if backend servers are using self-signed certificates
+        `-r`: enable resale
 
 
 

--- a/include/fdo.h
+++ b/include/fdo.h
@@ -43,6 +43,9 @@ typedef enum {
 	FDO_STATE_ERROR
 } fdo_sdk_device_state;
 
+extern char *mfg_addr;
+extern bool use_mfg_addr_bin;
+
 #if defined(SELF_SIGNED_CERTS_SUPPORTED)
 extern bool useSelfSignedCerts;
 #endif


### PR DESCRIPTION
Add "-ip" runtime argument to take input for manufacturer address. 
If -ip not specified, manufacturer_addr.bin file used.