### PR TITLE
Fix onboarding when using RVByPass with SNI

### DIFF
--- a/lib/fdonet.c
+++ b/lib/fdonet.c
@@ -507,8 +507,6 @@ bool connect_to_manufacturer(fdo_ip_address_t *ip, const char *dn,
 	}
 
 	if (ip && ip->length > 0) {
-		LOG(LOG_DEBUG, "using IP\n");
-
 		connect_ok = fdo_con_connect(ip, dn, port, tls);
 		if ((connect_ok == -1) && retries--) {
 			LOG(LOG_INFO, "Failed to connect to Manufacturer "
@@ -590,8 +588,6 @@ bool connect_to_rendezvous(fdo_ip_address_t *ip, const char *dn, uint16_t port,
 	}
 
 	if (ip && ip->length > 0) {
-		LOG(LOG_DEBUG, "using IP\n");
-
 		connect_ok = fdo_con_connect(ip, dn, port, tls);
 		if ((connect_ok == -1) && retries--) {
 			LOG(LOG_INFO, "Failed to connect to Rendezvous server: "
@@ -675,8 +671,6 @@ bool connect_to_owner(fdo_ip_address_t *ip, const char *dn, uint16_t port,
 	}
 
 	if (ip && ip->length > 0) {
-		LOG(LOG_DEBUG, "using IP\n");
-
 		connect_ok = fdo_con_connect(ip, dn, port, tls);
 		if ((connect_ok == -1) && retries--) {
 			LOG(LOG_INFO,

--- a/lib/include/fdoprotctx.h
+++ b/lib/include/fdoprotctx.h
@@ -27,7 +27,7 @@ typedef struct fdo_prot_ctx_s {
 	bool (*protrun)(fdo_prot_t *ps);
 	fdo_ip_address_t *host_ip;
 	uint16_t host_port;
-	const char *host_dns;
+	char *host_dns;
 	fdo_ip_address_t *resolved_ip;
 } fdo_prot_ctx_t;
 

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -422,6 +422,8 @@ int32_t fdo_curl_connect(fdo_ip_address_t *ip_addr, const char *dn,
 		}
 #endif
 		if (enable_sni) {
+			LOG(LOG_DEBUG, "Using DNS\n");
+
 			if (snprintf_s_si(temp, HTTP_MAX_URL_SIZE, "%s:%d",
 					  (char *)dn, port) < 0) {
 				LOG(LOG_ERROR, "Snprintf() failed!\n");
@@ -455,6 +457,7 @@ int32_t fdo_curl_connect(fdo_ip_address_t *ip_addr, const char *dn,
 			}
 		} else {
 			(void)dn;
+			LOG(LOG_DEBUG, "Using IP\n");
 			if (snprintf_s_si(temp, HTTP_MAX_URL_SIZE, "%s:%d",
 					  ip_ascii, port) < 0) {
 				LOG(LOG_ERROR, "Snprintf() failed!\n");
@@ -883,13 +886,15 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 #if defined(MTLS)
 	curlCode = curl_easy_setopt(curl, CURLOPT_SSLCERT, (char *)SSL_CERT);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to select client certificate.\n");
+		LOG(LOG_ERROR, "CURL_ERROR: Could not able to select client "
+			       "certificate.\n");
 		goto err;
 	}
 
 	curlCode = curl_easy_setopt(curl, CURLOPT_SSLKEY, (char *)SSL_KEY);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to select client key.\n");
+		LOG(LOG_ERROR,
+		    "CURL_ERROR: Could not able to select client key.\n");
 		goto err;
 	}
 #endif

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -472,14 +472,14 @@ int32_t fdo_curl_connect(fdo_ip_address_t *ip_addr, const char *dn,
 		curlCode = curl_easy_setopt(curl, CURLOPT_URL, url);
 		if (curlCode != CURLE_OK) {
 			LOG(LOG_ERROR,
-			    "CURL_ERROR: Could not able to pass url.\n");
+			    "CURL_ERROR: Unable to pass url.\n");
 			goto err;
 		}
 
 		curlCode = curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
 		if (curlCode != CURLE_OK) {
 			LOG(LOG_ERROR,
-			    "CURL_ERROR: Could not able connect to host.\n");
+			    "CURL_ERROR: Unable to connect to host.\n");
 			goto err;
 		}
 
@@ -886,7 +886,7 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 #if defined(MTLS)
 	curlCode = curl_easy_setopt(curl, CURLOPT_SSLCERT, (char *)SSL_CERT);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to select client "
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to select client "
 			       "certificate.\n");
 		goto err;
 	}
@@ -894,20 +894,20 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	curlCode = curl_easy_setopt(curl, CURLOPT_SSLKEY, (char *)SSL_KEY);
 	if (curlCode != CURLE_OK) {
 		LOG(LOG_ERROR,
-		    "CURL_ERROR: Could not able to select client key.\n");
+		    "CURL_ERROR: Unable to select client key.\n");
 		goto err;
 	}
 #endif
 
 	curlCode = curl_easy_setopt(curl, CURLOPT_URL, msg_header->data);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to pass url.\n");
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to pass url.\n");
 		goto err;
 	}
 
 	curlCode = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, msg_header);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to pass header.\n");
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to pass header.\n");
 		goto err;
 	}
 
@@ -926,7 +926,7 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	curlCode = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, buf);
 	if (curlCode != CURLE_OK) {
 		LOG(LOG_ERROR,
-		    "CURL_ERROR: Could not able to pass POST data.\n");
+		    "CURL_ERROR: Unable to pass POST data.\n");
 		goto err;
 	}
 
@@ -939,7 +939,7 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	curlCode =
 	    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, WriteMemoryCallback);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to pass header "
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to pass header "
 			       "WriteMemoryCallback.\n");
 		goto err;
 	}
@@ -958,14 +958,14 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 				    (void *)&temp_header_buf);
 	if (curlCode != CURLE_OK) {
 		LOG(LOG_ERROR,
-		    "CURL_ERROR: Could not able to pass header buffer.\n");
+		    "CURL_ERROR: Unable to pass header buffer.\n");
 		goto err;
 	}
 
 	curlCode =
 	    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to pass "
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to pass "
 			       "WriteMemoryCallback.\n");
 		goto err;
 	}
@@ -974,13 +974,13 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 	    curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&temp_body_buf);
 	if (curlCode != CURLE_OK) {
 		LOG(LOG_ERROR,
-		    "CURL_ERROR: Could not able to pass body buffer.\n");
+		    "CURL_ERROR: Unable to pass body buffer.\n");
 		goto err;
 	}
 
 	curlCode = curl_easy_setopt(curl, CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L);
 	if (curlCode != CURLE_OK) {
-		LOG(LOG_ERROR, "CURL_ERROR: Could not able to suppress connect "
+		LOG(LOG_ERROR, "CURL_ERROR: Unable to suppress connect "
 			       "headers.\n");
 		goto err;
 	}


### PR DESCRIPTION
When using RVByPass, prot_ctx->host_dns was pointing to an invalid value after msg 70. Fixed it by copying host_dns value to prot_ctx->host_dns instead of pointing prot_ctx->host_dns to host_dns.