### PR TITLE
Disable setting "Expect 100" in request header when request data size is larger than 1024 bytes

### DIFF
--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -877,6 +877,10 @@ int32_t fdo_con_send_recv_message(uint32_t protocol_version,
 		goto err;
 	}
 
+	if (length > REST_MAX_MSGHDR_SIZE) {
+		msg_header = curl_slist_append(msg_header, "Expect:");
+	}
+
 	curlCode = curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 0L);
 	if (curlCode != CURLE_OK) {
 		LOG(LOG_ERROR, "CURL_ERROR: Could not disable connect only.\n");


### PR DESCRIPTION
Curl automatically sets it when the request is a POST and the data size is larger than 1024 bytes. Requests with the Expect: 100-Continue header have an increased probability of becoming separated from one another, and hence returning with an error.
It can be disabled by setting the Expect: header to the empty string.