### PR TITLE
Update: Add implementation for CA certificate retrieval

### DIFF
--- a/cmake/blob_path.cmake
+++ b/cmake/blob_path.cmake
@@ -32,6 +32,12 @@ if(TARGET_OS MATCHES linux)
     )
     endif()
 
+  if (${CA} MATCHES true)
+    client_sdk_compile_definitions(
+      -DSSL_CERT=\"${BLOB_PATH}/certs/ca-cert.pem\"
+    )
+    endif()
+
   if (${BUILD_MFG_TOOLKIT} MATCHES true)
     client_sdk_compile_definitions(
       -DMAC_ADDRESSES=\"${BLOB_PATH}/data/mac_addresses.bin\"

--- a/cmake/cli_input.cmake
+++ b/cmake/cli_input.cmake
@@ -30,6 +30,7 @@ set (TPM2_TCTI_TYPE tabrmd)
 set (RESALE true)
 set (REUSE true)
 set (MTLS false)
+set (CA false)
 set (GET_DEV_SERIAL false)
 set (LOCK_TPM true)
 
@@ -859,6 +860,33 @@ endif()
 
 set(CACHED_MTLS ${MTLS} CACHE STRING "Selected MTLS")
 message("Selected MTLS ${MTLS}")
+###########################################
+# FOR CA RETRIEVAL
+get_property(cached_CA_value CACHE CA PROPERTY VALUE)
+
+set(CA_cli_arg ${cached_CA_value})
+if(CA_cli_arg STREQUAL CACHED_CA)
+  unset(CA_cli_arg)
+endif()
+
+set(CA_app_cmake_lists ${CA})
+if(cached_CA_value STREQUAL CA)
+  unset(CA_app_cmake_lists)
+endif()
+
+if(DEFINED CACHED_CA)
+  if ((DEFINED CA_cli_arg) AND (NOT(CACHED_CA STREQUAL CA_cli_arg)))
+    message(WARNING "Need to do make pristine before cmake args can change.")
+  endif()
+  set(CA ${CACHED_CA})
+elseif(DEFINED CA_cli_arg)
+  set(CA ${CA_cli_arg})
+elseif(DEFINED CA_app_cmake_lists)
+  set(CA ${CA_app_cmake_lists})
+endif()
+
+set(CACHED_CA ${CA} CACHE STRING "Selected CA")
+message("Selected CA ${CA}")
 ###########################################
 # FOR GET_DEV_SERIAL
 get_property(cached_get_dev_serial_value CACHE GET_DEV_SERIAL PROPERTY VALUE)

--- a/cmake/extension.cmake
+++ b/cmake/extension.cmake
@@ -276,6 +276,10 @@ if(${MTLS} STREQUAL true)
   client_sdk_compile_definitions(-DMTLS)
 endif()
 
+if(${CA} STREQUAL true)
+  client_sdk_compile_definitions(-DCA)
+endif()
+
 if(${GET_DEV_SERIAL} STREQUAL true)
   client_sdk_compile_definitions(-DGET_DEV_SERIAL)
 endif()

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -480,6 +480,13 @@ int32_t fdo_curl_connect(fdo_ip_address_t *ip_addr, const char *dn,
 			goto err;
 		}
 
+#if defined(CA)
+		curlCode = curl_easy_setopt(curl, CURLOPT_CAINFO, (char *)SSL_CERT);
+		if (curlCode != CURLE_OK) {
+			LOG(LOG_ERROR, "CURL_ERROR: Unable to set CA info path.\n");
+			goto err;
+		}
+#endif
 		res = curl_easy_perform(curl);
 		if (res != CURLE_OK) {
 			LOG(LOG_ERROR, "Error: %s\n", curl_easy_strerror(res));


### PR DESCRIPTION
This pull request implements the functionality to retrieve a CA certificate in the FIDO Device Onboard client SDK.
The main changes include:
- Addition of conditional compilation options to include the CA certificate path. (cmake/blob_path.cmake, cmake/extension.cmake)
- Implementation of logic to manage the configuration through CMake variables. (cmake/cli_input.cmake)
- Integration of the CA certificate in cURL calls. (network/network_if_linux.c)