### PR TITLE
Fix connection header spelling

### DIFF
--- a/network/rest_interface.c
+++ b/network/rest_interface.c
@@ -350,7 +350,7 @@ bool construct_rest_header(rest_ctx_t *rest_ctx, struct curl_slist **msg_header)
 		goto err;
 	}
 	*msg_header = curl_slist_append(*msg_header, temp1);
-	*msg_header = curl_slist_append(*msg_header, "_connection: keep-alive");
+	*msg_header = curl_slist_append(*msg_header, "Connection: keep-alive");
 
 	if (memset_s(temp, REST_MAX_MSGHDR_SIZE, 0) != 0) {
 		ret = false;


### PR DESCRIPTION
Setup the FDO services within kubernetes with soem gateway / httproutes and envoy. Envoy or gateways in general will drop messages when the headers contain underscores. This seems to be a typo, although for all I know this was intentional?